### PR TITLE
Current changes gathered from the seeg and simulador-energia projects

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -299,7 +299,7 @@ Style/LineEndConcatenation:
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
-  Max: 120
+  Max: 80
   AllowHeredoc: true
   AllowURI: true
   URISchemes:

--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -5,7 +5,6 @@ AllCops:
     - config/**/*
     - node_modules/**/*
     - Rakefile
-  RunRailsCops: true
 
 Metrics/AbcSize:
   Description: >-
@@ -678,6 +677,9 @@ Performance/StringReplacement:
   Enabled: false
 
 # Rails
+
+Rails:
+  Enabled: true
 
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'

--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -1,9 +1,21 @@
 AllCops:
   Exclude:
     - config.ru
-    - bin/**/*
     - db/**/*
     - config/**/*
+    - node_modules/**/*
+    - Rakefile
+  RunRailsCops: true
+
+Metrics/AbcSize:
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
+  Enabled: true
+  Max: 20
+  Exclude:
+    - bin/setup
 
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
@@ -13,6 +25,20 @@ Style/Alias:
   Description: 'Use alias_method instead of alias.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#alias-method'
   Enabled: false
+
+Style/AlignParameters:
+  Description: >-
+                 Align the parameters of a method call if they span more
+                 than one line.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-double-indent'
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+
+Style/AndOr:
+  Description: 'Use &&/|| instead of and/or.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-and-or-or'
+  Enabled: true
+  EnforcedStyle: conditionals
 
 Style/ArrayJoin:
   Description: 'Use Array#join instead of Array#*.'
@@ -34,9 +60,61 @@ Style/Attr:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#attr'
   Enabled: false
 
+Style/BlockDelimiters:
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+  Enabled: true
+  EnforcedStyle:
+    # This looks at the usage of a block's method to determine its type (e.g. is
+    # the result of a `map` assigned to a variable or passed to another
+    # method) but exceptions are permitted in the `ProceduralMethods`,
+    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    semantic
+  ProceduralMethods:
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
+  FunctionalMethods:
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
+  IgnoredMethods:
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone.
+    - lambda
+    - proc
+    - it
+
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count'
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Description: 'Enforce braces style around hash parameters.'
   Enabled: false
 
 Style/CaseEquality:
@@ -87,6 +165,12 @@ Style/CommentAnnotation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
   Enabled: false
 
+Style/CommentIndentation:
+  Description: 'Indentation of comments.'
+  Enabled: true
+  Exclude:
+    - spec/spec_helper.rb
+
 Metrics/CyclomaticComplexity:
   Description: >-
                  A complexity metric that is strongly correlated to the number
@@ -119,6 +203,12 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: false
+
+Style/EmptyLines:
+  Description: "Don't use several empty lines in a row."
+  Enabled: true
+  Exclude:
+    - bin/**/*
 
 Style/EmptyLiteral:
   Description: 'Prefer literals to Array.new/Hash.new/String.new.'
@@ -166,6 +256,15 @@ Style/GuardClause:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
   Enabled: false
 
+Style/HashSyntax:
+  Description: >-
+                 Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax
+                 { :a => 1, :b => 2 }.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-literals'
+  Enabled: true
+  Exclude:
+    - lib/tasks/**/*
+
 Style/IfUnlessModifier:
   Description: >-
                  Favor modifier if/unless usage when you have a
@@ -201,12 +300,17 @@ Style/LineEndConcatenation:
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
-  Max: 80
+  Max: 120
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#short-methods'
-  Enabled: false
+  Enabled: true
 
 Style/ModuleFunction:
   Description: 'Checks for usage of `extend self` in modules.'
@@ -326,16 +430,38 @@ Style/SignalException:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#fail-method'
   Enabled: false
 
+Style/SpaceAroundEqualsInParameterDefault:
+  Description: >-
+                 Checks that the equals signs in parameter default assignments
+                 have or don't have surrounding space depending on
+                 configuration.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-around-equals'
+  Enabled: true
+  EnforcedStyle: space
+
 Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms'
   Enabled: false
 
+Style/SpaceInsideBrackets:
+  Description: 'No spaces after [ or before ].'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: false
+
+Style/SpaceInsideParens:
+  Description: 'No spaces after ( or before ).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: true
+  Exclude:
+    - spec/**/*
+
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
   Enabled: true
+  ConsistentQuotesInMultiline: true
 
 Style/TrailingCommaInLiteral:
   Description: 'Checks for trailing comma in parameter lists and literals.'

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -3,7 +3,6 @@ Ruby
 
 [Sample](sample.rb)
 
-* Avoid conditional modifiers (lines that end with conditionals).
 * Avoid multiple assignments per line (`one, two = 1, 2`).
 * Avoid organizational comments (`# Validations`).
 * Avoid ternary operators (`boolean ? true : false`). Use multi-line `if`
@@ -19,7 +18,7 @@ Ruby
 * Prefer `select` over `find_all`.
 * Prefer `map` over `collect`.
 * Prefer `reduce` over `inject`.
-* Prefer double quotes for strings.
+* Prefer single quotes for strings.
 * Prefer `&&` and `||` over `and` and `or`.
 * Prefer `!` over `not`.
 * Prefer `&:method_name` to `{ |item| item.method_name }` for simple method

--- a/style/ruby/sample.rb
+++ b/style/ruby/sample.rb
@@ -8,9 +8,9 @@ class SomeClass
   end
 
   def method_with_arguments(argument_one, argument_two)
-    a_really_long_line_that_is_broken_up_over_multiple_lines_and.
-      subsequent_lines_are_indented_and.
-      each_method_lives_on_its_own_line
+    a_really_long_line_that_is_broken_up_over_multiple_lines_and
+      .subsequent_lines_are_indented_and
+      .each_method_lives_on_its_own_line
   end
 
   def method_with_required_keyword_arguments(one:, two:)


### PR DESCRIPTION
Adiciona as mudanças acumuladas com o tempo de desenvolvimento do SEEG e do Simulador de Energia.

Alguns pontos, embora eu já tenha me adiantado e passado para a configuração do rubocop (porque estava na configuração dos projetos anteriormente citados), eu acho que merecem uma discussão para que possamos decidir em conjunto se devemos incorporar ao nosso Style guide ou não.

O primeiro é um Cop chamado `IfUnlessModifier`. Atualmente está desativado. 
Se ativado, irá disparar em ifs/unless cujo corpo só possui uma linha.
### Ruim (para o cop)

``` ruby
[:pib, :urban_population, :total_population, :territory_area].each do |territory_card_info|
  define_method "last_#{territory_card_info}" do
    territory_card = territory_cards.where.not(territory_card_info => nil).order(year: :desc).take

    if territory_card
      territory_card.send(territory_card_info)
    end
  end
end
```
### Bom (para o cop)

``` ruby
[:pib, :urban_population, :total_population, :territory_area].each do |territory_card_info|
  define_method "last_#{territory_card_info}" do
    territory_card = territory_cards.where.not(territory_card_info => nil).order(year: :desc).take
    territory_card.send(territory_card_info) if territory_card
  end
end
```

Eu particularmente acho melhor manter desativado pois tem alguns contextos (incluindo o acima) em que um if de uma linha deixa as coisas mais legíveis.

O segundo cop se chama `ClassAndModuleChildren`, e define se módulos devem ser declarados ao redor da classe ou se incluído direto no nome da classe na declaração.
### Ruim (para o cop)

``` ruby
class Ranking::States
  def self.years
    Year.all
  end
end
```
### Bom (para o cop)

``` ruby
module Ranking
  class States
    def self.years
      Year.all
    end
  end
end
```

Na minha opinião deveria se manter `ativo` e com a configuração `nested` (que é a padrão), que dá preferência à declaração explícita do módulo. Caso seja utilizada a configuração `compact`, ele vai inverter as situações acima e alertar para quando houver uma declaração explícita.

O terceiro cop que eu acho que merece discussão é o `LineLength` (self-explanatory), que eu voto em deixar ativado com um limite de 120 caracteres (em vez dos convencionais 80). Sei que 80 é considerado standard, mas acho que às vezes ele limita demais. Acho um limite de 120 caracteres mais sensível, mas o meu monitor pode estar me atrapalhando nisso, já que uso resoluções grandes.

80 caracteres

``` yaml
Metrics/LineLength:
  Description: 'Limit lines to 80 characters.'
  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
```

120 caracteres

``` yaml
Metrics/CyclomaticComplexity:
  Description: 'A complexity metric that is strongly correlated to the number of test cases needed to validate a method.'
  Enabled: false
```

O quarto cop, é o `StringLiterals`. Basicamente, devemos dar preferência a double quotes all the time? Ou a single quotes e usar double somente quando houver interpolação? Eu já me acostumei a usar single quotes pra tudo porque é o padrão do rubocop, mas antes eu costumava usar sempre double quotes.

Por último, o cop `MethodLength`. Ele por padrão limita um método a ter 10 linhas no máximo. A tentativa de me manter dentro das cinco linhas da Sandi Metz já me fez repensar muito código e acabar re-escrevendo ele de maneira mais bonita, então acho interessante esse cop se manter ativado. 

Eu acho que existem casos especiais em que se pode passar desse limite, mas nesse caso pode-se adicionar uma exceção para esse arquivo específico num arquivo de configuração específica do rubocop para aquele projeto (incluído no `.rubocop.yml` através de `inherit_from`).

Se acharem que fica muito pesado discutir isso aqui, sintam-se livres para levar a discussão para outro lugar. Talvez acabe "sujando" a área de discussão do PR. :)
