### PR TITLE
Add before and sequence to BlockDelimiters/IgnoredMethods

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -106,6 +106,8 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
+    - before
+    - sequence
 
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'


### PR DESCRIPTION
This way we can write in the functional and procedural form.
E.g:

``` ruby
before { sign_in }
```

and

``` ruby
before do
  sign_in
  create_post
end
```
